### PR TITLE
[Solved] ManagedPlugins always enabled.

### DIFF
--- a/pyutilib/component/core/core.py
+++ b/pyutilib/component/core/core.py
@@ -957,7 +957,10 @@ class Plugin(with_metaclass(PluginMeta, object)):
 
     def enabled(self):
         """Return value indicating if this plugin is enabled"""
-        return self._enable
+        enable = self._enable
+        if hasattr(enable, 'get_value'):
+            enable = self._enable.get_value()
+        return enable
 
     def __repr__(self, simple=False):
         """Return a textual representation of the plugin."""


### PR DESCRIPTION
For ManagedPlugins the _enable variable is of the type BoolOption.
BoolOption evaluates to True. So all of the ManagedPlugins were always loaded in a enabled state.
This patch should solve that, not in the most elegant way, but in the way with the least amount of side effects.

Signed-off-by: Gerald Ebberink <g.h.p.ebberink@saxion.nl>