### PR TITLE
ConfigBlock: allow overriding attributes when copying

### DIFF
--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -171,13 +171,26 @@ class ConfigBase(object):
             # of setting self.__dict__[key] = val.
             object.__setattr__(self, key, val)
 
-    def __call__(self, value=NoArgument):
+    def __call__(self, value=NoArgument, domain=NoArgument,
+                 description=NoArgument, doc=NoArgument, visibility=NoArgument):
         ans = self.__class__()
         ans._default     = self.value()
-        ans._domain      = self._domain
-        ans._description = self._description
-        ans._doc         = self._doc
-        ans._visibility  = self._visibility
+        if domain is NoArgument:
+            ans._domain = self._domain
+        else:
+            ans._domain = domain
+        if description is NoArgument:
+            ans._description = self._description
+        else:
+            ans._description = _strip_indentation(description)
+        if doc is NoArgument:
+            ans._doc = self._doc
+        else:
+            ans._doc = _strip_indentation(doc)
+        if visibility is NoArgument:
+            ans._visibility = self._visibility
+        else:
+            ans._visibility = visibility
         if self.__class__ is ConfigBlock:
             ans._implicit_declaration = self._implicit_declaration
             ans._implicit_domain = self._implicit_domain

--- a/pyutilib/misc/tests/test_config.py
+++ b/pyutilib/misc/tests/test_config.py
@@ -144,8 +144,8 @@ class Test(unittest.TestCase):
         }
 
     # Utility method for generating and validating a template description
-    def _validateTemplate(self, reference_template, **kwds):
-        test = self.config.generate_yaml_template(**kwds)
+    def _validateTemplate(self, config, reference_template, **kwds):
+        test = config.generate_yaml_template(**kwds)
         width = kwds.get('width', 80)
         indent = kwds.get('indent_spacing', 2)
         sys.stdout.write(test)
@@ -183,7 +183,7 @@ flushing:
     max pipes: 2            # Maximum number of pipes to close
     response time: 60.0     # Time [min] between detection and closing valves
 """
-        self._validateTemplate(reference_template)
+        self._validateTemplate(self.config, reference_template)
 
     def test_template_3space(self):
         reference_template = """# Basic configuration for Flushing models
@@ -215,7 +215,8 @@ flushing:
       response time: 60.0     # Time [min] between detection and closing
                               #   valves
 """
-        self._validateTemplate(reference_template, indent_spacing=3)
+        self._validateTemplate(self.config, reference_template,
+                               indent_spacing=3)
 
     def test_template_4space(self):
         reference_template = """# Basic configuration for Flushing models
@@ -247,7 +248,8 @@ flushing:
         response time: 60.0     # Time [min] between detection and closing
                                 #   valves
 """
-        self._validateTemplate(reference_template, indent_spacing=4)
+        self._validateTemplate(self.config, reference_template,
+                               indent_spacing=4)
 
     def test_template_3space_narrow(self):
         reference_template = """# Basic configuration for Flushing models
@@ -280,7 +282,8 @@ flushing:
       response time: 60.0     # Time [min] between detection and closing
                               #   valves
 """
-        self._validateTemplate(reference_template, indent_spacing=3, width=72)
+        self._validateTemplate(self.config, reference_template,
+                               indent_spacing=3, width=72)
 
     def test_display_default(self):
         reference = """network:
@@ -1506,6 +1509,43 @@ Node information:
         self.assertEqual(config.a_b, 10)
         self.assertEqual(config.a_c, 20)
         self.assertEqual(config.a_d_e, 30)
+
+    def test_call_options(self):
+        config = ConfigBlock(description="base description",
+                             doc="base doc",
+                             visibility=1)
+        config.declare("a", ConfigValue(domain=int, doc="a doc", default=1))
+        config.declare("b", config.get("a")(2))
+        config.declare("c", config.get("a")(domain=float, doc="c doc"))
+
+        reference_template = """# base description
+"""
+        self._validateTemplate(config, reference_template)
+        reference_template = """# base description
+a: 1
+b: 2
+c: 1.0
+"""
+        self._validateTemplate(config, reference_template, visibility=1)
+
+        simple_copy = config()
+        self._validateTemplate(simple_copy, reference_template, visibility=1)
+        self.assertEqual(simple_copy._doc, "base doc")
+        self.assertEqual(simple_copy._description, "base description")
+        self.assertEqual(simple_copy._visibility, 1)
+
+        mod_copy = config(description="new description",
+                          doc="new doc",
+                          visibility=0)
+        reference_template = """# new description
+a: 1
+b: 2
+c: 1.0
+"""
+        self._validateTemplate(mod_copy, reference_template, visibility=0)
+        self.assertEqual(mod_copy._doc, "new doc")
+        self.assertEqual(mod_copy._description, "new description")
+        self.assertEqual(mod_copy._visibility, 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary/Motivation:
This change was motivated by @jghouse88 where he was using a ConfigBlock as a template for several sections of a Config and wanted to overwrite the `doc` field.  This PR supports the following:

```
template = ConfigBlock()
template.declare('a', ConfigValue( #...
    )
# ....
config = ConfigBlock()
config.declare("thing 1", template(doc="configuration for thing 1"))
config.declare("thing 2", template(doc="configuration for thing 2"))
```

## Changes proposed in this PR:
- Adding the ability to override constructor arguments (default, doc, description, visibility, domain, implicit, implicit_domain) when duplicating an object through `__call__()`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
