### PR TITLE
Adding an option to ConfigBase.__call__ to preserve implicit values

### DIFF
--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -224,11 +224,12 @@ class ConfigBase(object):
         ans = self.__class__(**kwds)
         if isinstance(self, ConfigBlock):
             for k in self._decl_order:
-                if k in self._declared or preserve_implicit:
+                if preserve_implicit or k in self._declared:
                     v = self._data[k]
                     ans._data[k] = _tmp = v(preserve_implicit=preserve_implicit)
                     ans._decl_order.append(k)
-                    ans._declared.add(k)
+                    if k in self._declared:
+                        ans._declared.add(k)
                     _tmp._parent = ans
                     _tmp._name = v._name
         else:

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -173,7 +173,8 @@ class ConfigBase(object):
 
     def __call__(self, value=NoArgument, default=NoArgument, domain=NoArgument,
                  description=NoArgument, doc=NoArgument, visibility=NoArgument,
-                 implicit=NoArgument, implicit_domain=NoArgument):
+                 implicit=NoArgument, implicit_domain=NoArgument,
+                 preserve_implicit=False):
         # We will pass through overriding arguments to the constructor.
         # This way if the constructor does special processing of any of
         # the arguments (like implicit_domain), we don't have to repeat
@@ -223,9 +224,9 @@ class ConfigBase(object):
         ans = self.__class__(**kwds)
         if isinstance(self, ConfigBlock):
             for k in self._decl_order:
-                if k in self._declared:
+                if k in self._declared or preserve_implicit:
                     v = self._data[k]
-                    ans._data[k] = _tmp = v()
+                    ans._data[k] = _tmp = v(preserve_implicit=preserve_implicit)
                     ans._decl_order.append(k)
                     ans._declared.add(k)
                     _tmp._parent = ans

--- a/pyutilib/misc/tests/test_config.py
+++ b/pyutilib/misc/tests/test_config.py
@@ -1513,10 +1513,14 @@ Node information:
     def test_call_options(self):
         config = ConfigBlock(description="base description",
                              doc="base doc",
-                             visibility=1)
+                             visibility=1,
+                             implicit=True)
         config.declare("a", ConfigValue(domain=int, doc="a doc", default=1))
         config.declare("b", config.get("a")(2))
         config.declare("c", config.get("a")(domain=float, doc="c doc"))
+        config.d = 0
+        config.e = ConfigBlock(implicit=True)
+        config.e.a = 0
 
         reference_template = """# base description
 """
@@ -1525,9 +1529,23 @@ Node information:
 a: 1
 b: 2
 c: 1.0
+d: 0
+e:
+  a: 0
 """
         self._validateTemplate(config, reference_template, visibility=1)
 
+        # Preserving implicit values should leave the copy the same as
+        # the original
+        implicit_copy = config(preserve_implicit=True)
+        self._validateTemplate(config, reference_template, visibility=1)
+
+        # Simple copies strip out the implicitly-declared values
+        reference_template = """# base description
+a: 1
+b: 2
+c: 1.0
+"""
         simple_copy = config()
         self._validateTemplate(simple_copy, reference_template, visibility=1)
         self.assertEqual(simple_copy._doc, "base doc")


### PR DESCRIPTION
## Summary/Motivation:
When using ConfigBlocks for configuring complex objects (like solvers in Pyomo), it becomes convenient to create temporary ConfigBlocks for holding transient options.  We do that by calling the ConfigBlock.  The catch is that if the block permits implicit keys, then we will want to preserve those implicit keys.

This PR adds a new option to `__call__` to cause the copy to preserve all implicitly-defined keys.

## Changes proposed in this PR:
- add `preserve_implicit` option to `ConfigBase.__call__()`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
