### PR TITLE
Uncategorized tests should not default to expensive

### DIFF
--- a/pyutilib/dev/tests/test_runtests.py
+++ b/pyutilib/dev/tests/test_runtests.py
@@ -13,12 +13,15 @@ class Test_Runtests(unittest.TestCase):
             del os.environ['PYUTILIB_UNITTEST_CATEGORY']
         stream_out = six.StringIO()
         pyutilib.misc.setup_redirect(stream_out)
-        runPyUtilibTests(['nosetests', '-v', '--no-xunit'] + args + 
-                         ['pyutilib.th.tests.test_pyunit'],
-                         use_exec=False)
+        rc = runPyUtilibTests(['nosetests', '-v', '--no-xunit'] + args +
+                              ['pyutilib.th.tests.test_pyunit'],
+                              use_exec=False)
         pyutilib.misc.reset_redirect()
         if oldCat is not None:
             os.environ['PYUTILIB_UNITTEST_CATEGORY'] = oldCat
+
+        if rc:
+            self.fail("running nosetests failed (rc=%s)" % (rc,))
 
         result = []
         for line in stream_out.getvalue().splitlines():
@@ -136,7 +139,7 @@ class Test_Runtests(unittest.TestCase):
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_fragile',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_fragile_smoke',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_multi',
-            'pyutilib.th.tests.test_pyunit.TestNoCategory.test_noCategory',
+            #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_noCategory',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_notExpensive',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_smoke',
         ]
@@ -158,7 +161,7 @@ class Test_Runtests(unittest.TestCase):
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_fragile',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_fragile_smoke',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_multi',
-            'pyutilib.th.tests.test_pyunit.TestNoCategory.test_noCategory',
+            #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_noCategory',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_notExpensive',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_smoke',
         ]
@@ -202,7 +205,7 @@ class Test_Runtests(unittest.TestCase):
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_fragile',
             #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_fragile_smoke',
             'pyutilib.th.tests.test_pyunit.TestNoCategory.test_multi',
-            #'pyutilib.th.tests.test_pyunit.TestNoCategory.test_noCategory',
+            'pyutilib.th.tests.test_pyunit.TestNoCategory.test_noCategory',
             'pyutilib.th.tests.test_pyunit.TestNoCategory.test_notExpensive',
             'pyutilib.th.tests.test_pyunit.TestNoCategory.test_smoke',
         ]

--- a/pyutilib/th/pyunit.py
+++ b/pyutilib/th/pyunit.py
@@ -259,7 +259,7 @@ class TestCase(unittest.TestCase):
     # The default test categories are 'smoke' and 'nightly' and 'expensive'
     smoke = 1
     nightly = 1
-    expensive = 1
+    expensive = 0
     fragile = 0
     _default_categories = True
     # If someone specifies a category, these are the default values of


### PR DESCRIPTION
## Summary/Motivation:
Currently uncategorized pyutilib.th tests default to "smoke, nightly, expensive".  This means that the "expensive" test jobs duplicate all of the tests that the smoke/nightly test jobs have already done, which seems redundant ('all' covers that use case).  This PR changes the default so that uncategorized tests are marked as "smoke, nightly," but not expensive.  This will reduce the amount of unnecessarily repeated tests in most testing setups.

## Changes proposed in this PR:
- remove "expensive" as a default category

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
