### PR TITLE
File comparison fixes

### DIFF
--- a/pyutilib/misc/tests/test_misc.py
+++ b/pyutilib/misc/tests/test_misc.py
@@ -317,12 +317,14 @@ yy: 2""")
         ] = pyutilib.misc.compare_file_with_numeric_values(
             currdir + "filecmp1.txt", currdir + "filecmp3.txt")
         if not flag or lineno != 4:
-            self.fail("test_file_compare1a - expected difference at line 4")
+            self.fail("test_file_compare1a - expected difference at line 4",
+                      ", got %s, %s" % (flag, lineno))
         [flag, lineno, diffstr
         ] = pyutilib.misc.compare_file_with_numeric_values(
             currdir + "filecmp1.txt", currdir + "filecmp4.txt")
         if not flag or lineno != 3:
-            self.fail("test_file_compare1a - expected difference at line 3")
+            self.fail("test_file_compare1a - expected difference at line 3"
+                      ", got %s, %s" % (flag, lineno))
         try:
             [flag, lineno, diffstr
             ] = pyutilib.misc.compare_file_with_numeric_values(


### PR DESCRIPTION
## Summary/Motivation:
Overhaul of pyutilib file comparison operators.  This simplifies the code and fixes issues with numeric comparisons.

## Changes proposed in this PR:
- simplifying the file comparison code
- adding both absolute and relative tolerances for numeric comparison
- fixing bug where consecutive numbers without spaces were not correctly
    parsed (i.e., "`-12.34-56.78-9.10`")

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
