### PR TITLE
Fix UnboundLocalError (subprocess died before reader threads started).

### DIFF
--- a/pyutilib/subprocess/processmngr.py
+++ b/pyutilib/subprocess/processmngr.py
@@ -558,6 +558,7 @@ def run_command(cmd,
             simpleCase = False
 
         out_th = []
+        th = None
         GlobalData.signal_handler_busy = False
         if simpleCase:
             #
@@ -687,10 +688,16 @@ def run_command(cmd,
         #
         for p in out_th:
             os.close(p[2])
-        th.join()
+        if th is not None:
+            # Note, there is a condition where the subprocess can die
+            # very quickly (raising an OSError) before the reader
+            # threads have a chance to be set up.  Testing for None
+            # avoids joining a thread that doesn't exist.
+            th.join()
         for p in out_th:
             os.close(p[1])
-        del th
+        if th is not None:
+            del th
     if outfile is not None:
         stdout_arg.close()
     elif tmpfile is not None and not ignore_output:


### PR DESCRIPTION
## Summary/Motivation:
This resolves an exception that is due to a timing error where a subprocess can die before the I/O reader thread is launched.  The cleanup routines need to verify that the threads were created before joining them.

The original error was reported on the [Pyomo Forum](https://groups.google.com/d/msg/pyomo-forum/6eStBMj8HbU/UCyXeDxRGQAJ)

## Changes proposed in this PR:
- verify that the reader thread was created before closing it

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
