### PR TITLE
Disable nose's use of docstrings for test descriptions

### DIFF
--- a/pyutilib/th/pyunit.py
+++ b/pyutilib/th/pyunit.py
@@ -294,6 +294,10 @@ class TestCase(unittest.TestCase):
         if not tmp is None:
             tmp[name] = value
 
+    def shortDescription(self):
+        # Disable nose's use of test docstrings for the test description.
+        return None
+
     def assertMatchesXmlBaseline(self,
                                  testfile,
                                  baseline,


### PR DESCRIPTION
## Summary/Motivation:
By default, `nose` will use and output the first line of a test's docstring when running tests instead of the more informative (and useful) module path and test function name.  Instead of going through all of Pyomo / PyUtilib and removing the use of docstrings, this change prevents nose from interrogating the docstring in the first place.

The net effect is that output from running `nosetests -v` will change output like:
```
Use a solver manager that delays the evaluation of responses, and verify that queue-ing multiple solves works. ... ok
Use a solver manager that delays the evaluation of responses, and verify that queue-ing multiple solves works. ... ok
Use a solver manager that delays the evaluation of responses, and verify that queue-ing multiple solves works. ... ok
Test Serial EvalManager - TestProblem1 ... ok
Test Serial SolverManager - Error with no optimizer ... ok
Test Serial SolverManager - Error with no queue solves ... ok
```
to
```
test_avail (pyomo.opt.tests.base.test_solver.OptSolverDebug) ... ok
test_problem_format (pyomo.opt.tests.base.test_solver.OptSolverDebug) ... ok
test_results_format (pyomo.opt.tests.base.test_solver.OptSolverDebug) ... ok
test_set_problem_format (pyomo.opt.tests.base.test_solver.OptSolverDebug) ... ok
test_set_results_format (pyomo.opt.tests.base.test_solver.OptSolverDebug) ... ok
```
## Changes proposed in this PR:
- "force" nose to output test name / path instead of docstring

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
