### PR TITLE
StreamIndenter fix for blank lines

### DIFF
--- a/pyutilib/misc/indent_io.py
+++ b/pyutilib/misc/indent_io.py
@@ -17,6 +17,7 @@ class StreamIndenter(object):
     def __init__(self, ostream, indent="        "):
         self.os = ostream
         self.indent = indent
+        self.stripped_indent = indent.rstrip()
         self.newline = True
 
     def __getattr__(self, name):
@@ -26,16 +27,27 @@ class StreamIndenter(object):
         if not len(data):
             return
         lines = data.split('\n')
-        if lines[0] and self.newline:
-            self.os.write(self.indent+lines[0])
+        if self.newline:
+            if lines[0]:
+                self.os.write(self.indent+lines[0])
+            else:
+                self.os.write(self.stripped_indent)
         else:
             self.os.write(lines[0])
-        for line in lines[1:]:
+        if len(lines) < 2:
+            self.newline = False
+            return
+        for line in lines[1:-1]:
             if line:
                 self.os.write("\n"+self.indent+line)
             else:
-                self.os.write("\n")
-        self.newline = not bool(lines[-1])
+                self.os.write("\n"+self.stripped_indent)
+        if lines[-1]:
+            self.os.write("\n"+self.indent+lines[-1])
+            self.newline = False
+        else:
+            self.os.write("\n")
+            self.newline = True
 
     def writelines(self, sequence):
         for x in sequence:

--- a/pyutilib/misc/indent_io.py
+++ b/pyutilib/misc/indent_io.py
@@ -22,20 +22,20 @@ class StreamIndenter(object):
     def __getattr__(self, name):
         return getattr(self.os, name)
 
-    def write(self, str):
-        if not len(str):
+    def write(self, data):
+        if not len(data):
             return
-        if self.newline:
-            self.os.write(self.indent)
-            self.newline = False
-        frag = str.rsplit('\n', 1)
-        self.os.write(frag[0].replace('\n', '\n' + self.indent))
-        if len(frag) > 1:
-            self.os.write('\n')
-            if len(frag[1]):
-                self.os.write(self.indent + frag[1])
+        lines = data.split('\n')
+        if lines[0] and self.newline:
+            self.os.write(self.indent+lines[0])
+        else:
+            self.os.write(lines[0])
+        for line in lines[1:]:
+            if line:
+                self.os.write("\n"+self.indent+line)
             else:
-                self.newline = True
+                self.os.write("\n")
+        self.newline = not bool(lines[-1])
 
     def writelines(self, sequence):
         for x in sequence:

--- a/pyutilib/misc/tests/test_io.py
+++ b/pyutilib/misc/tests/test_io.py
@@ -145,17 +145,22 @@ class IODebug(unittest.TestCase):
 
     def test_indenter_write(self):
         output = six.StringIO()
-        indenter = pyutilib.misc.StreamIndenter(output, "X")
+        indenter = pyutilib.misc.StreamIndenter(output, "X ")
         indenter.write("foo")
-        self.assertEqual(output.getvalue(), "Xfoo")
+        self.assertEqual(output.getvalue(), "X foo")
         indenter.write("\n")
-        self.assertEqual(output.getvalue(), "Xfoo\n")
+        self.assertEqual(output.getvalue(), "X foo\n")
         indenter.write("foo\n")
-        self.assertEqual(output.getvalue(), "Xfoo\nXfoo\n")
+        self.assertEqual(output.getvalue(), "X foo\nX foo\n")
         indenter.write("")
-        self.assertEqual(output.getvalue(), "Xfoo\nXfoo\n")
+        self.assertEqual(output.getvalue(), "X foo\nX foo\n")
+        indenter.write("\n")
+        self.assertEqual(output.getvalue(), "X foo\nX foo\nX\n")
         indenter.write("baz\nbin")
-        self.assertEqual(output.getvalue(), "Xfoo\nXfoo\nXbaz\nXbin")
+        self.assertEqual(output.getvalue(), "X foo\nX foo\nX\nX baz\nX bin")
+        indenter.write("a\nb\n\nc\n")
+        self.assertEqual(output.getvalue(),
+                         "X foo\nX foo\nX\nX baz\nX bina\nX b\nX\nX c\n")
 
         self.assertEqual(indenter.closed, False)
         indenter.close()


### PR DESCRIPTION
## Fixes: N/A

## Summary/Motivation:
This updates the StreamIndenter to rstrip the prefix when outputting blank lines.  This prevents outputting spaces on otherwise blank lines.

## Changes proposed in this PR:
- `rstrip` the prefix when writing otherwise blank lines

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
