### PR TITLE
Bugfix in Excel interface to avoid closing previously open Excel windows

### DIFF
--- a/pyutilib/excel/spreadsheet_win32com.py
+++ b/pyutilib/excel/spreadsheet_win32com.py
@@ -19,7 +19,11 @@ import os
 # Attempt to import win32com stuff.  If this fails, then
 # set a flag to tell the ExcelSpreadsheet class that it should
 # raise an exception in its constructor.
-#
+
+# BLN: Use DispatchEx instead of Dispatch to make sure we launch
+# BLN: a new instance of Excel, otherwise we unintentionally 
+# BLN: close any open Excel Windows when importing Pyomo 
+# BLN: See https://github.com/Pyomo/pyomo/issues/355
 from win32com.client import DispatchEx as Dispatch
 from pythoncom import CoInitialize, CoUninitialize, com_error
 

--- a/pyutilib/excel/spreadsheet_win32com.py
+++ b/pyutilib/excel/spreadsheet_win32com.py
@@ -20,7 +20,7 @@ import os
 # set a flag to tell the ExcelSpreadsheet class that it should
 # raise an exception in its constructor.
 #
-from win32com.client.dynamic import Dispatch
+from win32com.client import DispatchEx as Dispatch
 from pythoncom import CoInitialize, CoUninitialize, com_error
 
 from pyutilib.excel.base import ExcelSpreadsheet_base


### PR DESCRIPTION
## Fixes https://github.com/Pyomo/pyomo/issues/355

## Summary/Motivation:
Use `DispatchEx` instead of `Dispatch` to avoid interfering with open Excel windows. This solution was found based on this StackOverflow question: https://stackoverflow.com/questions/18648933/using-pywin32-what-is-the-difference-between-dispatch-and-dispatchex

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
