### PR TITLE
Improvements to import_file() and run_file()

### DIFF
--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -198,7 +198,7 @@ def run_file(filename, logfile=None, execdir=None):
             split_path.append(norm_file)
             norm_file = ''
     split_path.reverse()
-    currdir_ = os.path.join(split_path[:-1])
+    currdir_ = os.path.join(*tuple(split_path[:-1]))
     tmp_import = split_path[-1]
 
     name = ".".join((tmp_import).split(".")[:-1])

--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -175,7 +175,7 @@ def run_file(filename, logfile=None, execdir=None):
     #
     # Open logfile
     #
-    if not logfile is None:
+    if logfile is not None:
         sys.stderr.flush()
         sys.stdout.flush()
         save_stdout = sys.stdout

--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -198,7 +198,10 @@ def run_file(filename, logfile=None, execdir=None):
             split_path.append(norm_file)
             norm_file = ''
     split_path.reverse()
-    currdir_ = os.path.join(*tuple(split_path[:-1]))
+    if len(split_path) > 1:
+        currdir_ = os.path.join(*tuple(split_path[:-1]))
+    else:
+        currdir_ = '.'
     tmp_import = split_path[-1]
 
     name = ".".join((tmp_import).split(".")[:-1])

--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -92,11 +92,11 @@ def import_file(filename, context=None, name=None, clear_cache=False):
         else:
             if clear_cache and modulename in sys.modules:
                 del sys.modules[modulename]
-            if dirname is not None:
-                sys.path.insert(0, dirname)
-            else:
-                sys.path.insert(0, implied_dirname)
             try:
+                if dirname is not None:
+                    sys.path.insert(0, dirname)
+                else:
+                    sys.path.insert(0, implied_dirname)
                 module = __import__(modulename)
             except ImportError:
                 pass
@@ -129,8 +129,8 @@ def import_file(filename, context=None, name=None, clear_cache=False):
                                                             [dirname])
                 fp.close()
             else:
-                sys.path.insert(0, implied_dirname)
                 try:
+                    sys.path.insert(0, implied_dirname)
                     # find_module will return the .py file
                     # (never .pyc)
                     fp, pathname, description = imp.find_module(modulename)
@@ -202,29 +202,18 @@ def run_file(filename, logfile=None, execdir=None):
     # Run the module
     #
     try:
-        if not execdir is None:
+        tmp_path = list(sys.path)
+        if execdir is not None:
             tmp = os.getcwd()
             os.chdir(execdir)
-            tmp_path = sys.path
             sys.path = [execdir] + sys.path
         runpy.run_module(name, None, "__main__")
-        if not execdir is None:
+    finally:
+        # Mandatory cleanup
+        sys.path = tmp_path
+        if execdir is not None:
             os.chdir(tmp)
-            sys.path = tmp_path
-    except Exception:  #pragma:nocover
-        if not logfile is None:
+        if logfile is not None:
             OUTPUT.close()
             sys.stdout = save_stdout
             sys.stderr = save_stderr
-        raise
-    if currdir_ in sys.path:
-        sys.path.remove(currdir_)
-    if execdir in sys.path:
-        sys.path.remove(execdir)
-    #
-    # Close logfile
-    #
-    if not logfile is None:
-        OUTPUT.close()
-        sys.stdout = save_stdout
-        sys.stderr = save_stderr

--- a/pyutilib/misc/tests/import_exception.py
+++ b/pyutilib/misc/tests/import_exception.py
@@ -1,0 +1,3 @@
+import sys
+
+raise RuntimeError("raised during import")

--- a/pyutilib/misc/tests/import_main_exception.py
+++ b/pyutilib/misc/tests/import_main_exception.py
@@ -1,0 +1,5 @@
+import sys
+
+if __name__ == "__main__":
+    print("import_main_exception - main")
+    raise RuntimeError("raised from __main__")

--- a/pyutilib/misc/tests/import_main_exception.txt
+++ b/pyutilib/misc/tests/import_main_exception.txt
@@ -1,0 +1,1 @@
+import_main_exception - main

--- a/pyutilib/misc/tests/test_import.py
+++ b/pyutilib/misc/tests/test_import.py
@@ -55,6 +55,7 @@ class TestRunFile(unittest.TestCase):
         os.remove(currdir + "import2.log")
 
     def test_run_file_exception(self):
+        orig_path = list(sys.path)
         with self.assertRaisesRegexp(RuntimeError, "raised from __main__"):
             pyutilib.misc.run_file(
                 "import_main_exception.py",
@@ -65,6 +66,8 @@ class TestRunFile(unittest.TestCase):
                 currdir + "import_main_exception.log",
                 currdir + "import_main_exception.txt")[0])
         os.remove(currdir + "import_main_exception.log")
+        self.assertIsNot(orig_path, sys.path)
+        self.assertEqual(orig_path, sys.path)
 
 
 class TestImportFile(unittest.TestCase):
@@ -95,10 +98,13 @@ class TestImportFile(unittest.TestCase):
         if not "import1" in globals():
             self.fail("test_import_file - failed to import the import1.py file")
 
-    def test_run_file_exception(self):
+    def test_import_exception(self):
+        orig_path = list(sys.path)
         with self.assertRaisesRegexp(RuntimeError, "raised during import"):
             pyutilib.misc.run_file(
                 "import_exception.py", execdir=currdir)
+        self.assertIsNot(orig_path, sys.path)
+        self.assertEqual(orig_path, sys.path)
 
     def test1(self):
         try:

--- a/pyutilib/misc/tests/test_import.py
+++ b/pyutilib/misc/tests/test_import.py
@@ -54,6 +54,18 @@ class TestRunFile(unittest.TestCase):
                                                   currdir + "import2.txt")[0])
         os.remove(currdir + "import2.log")
 
+    def test_run_file_exception(self):
+        with self.assertRaisesRegexp(RuntimeError, "raised from __main__"):
+            pyutilib.misc.run_file(
+                "import_main_exception.py",
+                logfile=currdir + "import_main_exception.log", execdir=currdir)
+
+        self.assertFalse(
+            pyutilib.misc.comparison.compare_file(
+                currdir + "import_main_exception.log",
+                currdir + "import_main_exception.txt")[0])
+        os.remove(currdir + "import_main_exception.log")
+
 
 class TestImportFile(unittest.TestCase):
 
@@ -82,6 +94,11 @@ class TestImportFile(unittest.TestCase):
         pyutilib.misc.import_file(currdir + "import1.py", context=globals())
         if not "import1" in globals():
             self.fail("test_import_file - failed to import the import1.py file")
+
+    def test_run_file_exception(self):
+        with self.assertRaisesRegexp(RuntimeError, "raised during import"):
+            pyutilib.misc.run_file(
+                "import_exception.py", execdir=currdir)
 
     def test1(self):
         try:


### PR DESCRIPTION
## Fixes: N/A

## Summary/Motivation:
This improves the robustness of `import_file()` and `run_file()` so that the `sys.path` is not left in an altered state in the event that the import raises an exception.  This also switches to using tools from `sys.path` for performing path manipulations (instead of hard-coded `/` and `\` characters).

## Changes proposed in this PR:
- Ensure restoration of `sys.path` when imports raise exceptions
- Remove use of hard-coded `/` and `\` path separator characters.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
