### PR TITLE
Fixing import_file exception test

### DIFF
--- a/pyutilib/misc/tests/test_import.py
+++ b/pyutilib/misc/tests/test_import.py
@@ -101,8 +101,7 @@ class TestImportFile(unittest.TestCase):
     def test_import_exception(self):
         orig_path = list(sys.path)
         with self.assertRaisesRegexp(RuntimeError, "raised during import"):
-            pyutilib.misc.run_file(
-                "import_exception.py", execdir=currdir)
+            pyutilib.misc.import_file(currdir + "import_exception.py")
         self.assertIsNot(orig_path, sys.path)
         self.assertEqual(orig_path, sys.path)
 


### PR DESCRIPTION
## Fixes: N/A

## Summary/Motivation:
Fix a test that was calling the wrong function

## Changes proposed in this PR:
- call `import_file` (not `run_file`) in the test added in #70.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
