### PR TITLE
Fixes to setup.py and setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[metadata]
+license_files = LICENSE.txt
+
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -13,26 +13,8 @@ Setup for PyUtilib package
 
 import sys
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
-
-def _find_packages(path):
-    """
-    Generate a list of nested packages
-    """
-    pkg_list=[]
-    if not os.path.exists(path):
-        return []
-    if not os.path.exists(path+os.sep+"__init__.py"):
-        return []
-    else:
-        pkg_list.append(path)
-    for root, dirs, files in os.walk(path, topdown=True):
-        if root in pkg_list and "__init__.py" in files:
-            for name in dirs:
-                if os.path.exists(root+os.sep+name+os.sep+"__init__.py"):
-                    pkg_list.append(root+os.sep+name)
-    return [pkg for pkg in map(lambda x:x.replace(os.sep,"."), pkg_list)]
 
 def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as README:
@@ -45,8 +27,6 @@ def read(*rnames):
             if line.strip() and '[![' not in line:
                 break
         return line + README.read()
-
-packages = _find_packages('pyutilib')
 
 requires=[ 'nose', 'six' ]
 if sys.version_info < (2,7):
@@ -90,7 +70,7 @@ setup(name="PyUtilib",
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities'],
-      packages=packages,
+      packages=find_packages(),
       keywords=['utility'],
       namespace_packages=['pyutilib', 'pyutilib.component'],
       install_requires=requires,


### PR DESCRIPTION
## Fixes: #
This PR removes an unnecessary _find_packages routine from the setup.py file. 
## Summary/Motivation:
We want to use the built-in capabilities of setuptools for packaging PyUtilib and include the LICENSE file when packaging (mostly for Conda distribution).

## Changes proposed in this PR:
- Remove _find_packages and replace with setuptools' find_packages
- Include License file in setup.cfg (for Conda distribution)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
