### PR TITLE
Python 3.4 requires PyYAML<=5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   #- python: '2.7'
   #  env: PYRO="Pyro" JYTHON="org.python:jython-installer:2.7.0"
   - python: '3.4'
-    env: PYRO="Pyro4" YAML="pyyaml"
+    env: PYRO="Pyro4" YAML="pyyaml<=5.2"
   - python: '3.5'
     env: PYRO="Pyro4" YAML="pyyaml"
   - python: '3.6'
@@ -23,7 +23,7 @@ matrix:
     env: PYRO="Pyro4" YAML="pyyaml"
 install:
 - if [ -n "${JYTHON}" ]; then source install_jython.sh; fi
-- if [ -n "${YAML}" ]; then pip install pyyaml; fi
+- if [ -n "${YAML}" ]; then pip install "${YAML}"; fi
 - pip install xlrd
 - pip install $PYRO
 - pip install coverage


### PR DESCRIPTION
## Fixes: N/A

## Summary/Motivation:
This works around a problem with the PyYAML distribution where PyPI doesn't recognize the PyYAML 'python_requires' directive from setup.py.


## Changes proposed in this PR:
- force PyYAML<=5.2 for Python 3.4 tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
