### PR TITLE
Adding a compatibility shim for assertRaisesRegex

### DIFF
--- a/pyutilib/th/pyunit.py
+++ b/pyutilib/th/pyunit.py
@@ -30,7 +30,7 @@ else:
     using_unittest2 = True
     main = unittest.main
 
-from six import iteritems, itervalues
+from six import iteritems, itervalues, PY2
 
 #
 # Defer the pyutilib.misc import until it is actually needed.  If we
@@ -266,6 +266,11 @@ class TestCase(unittest.TestCase):
     # the default categories if the category() decorator omits them.
     unspecified_categories = {
         'smoke':0, 'nightly':0, 'expensive':0, 'fragile':0 }
+
+    if PY2:
+        # Compatibility shim: assertRaisesRegexp was renamed to
+        # assertRaisesRegex in Python 3.2
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
     def __init__(self, methodName='runTest'):
         unittest.TestCase.__init__(self, methodName)


### PR DESCRIPTION
## Fixes: Pyomo/pyomo#1283

## Summary/Motivation:
`assertRaisesRegexp` was added in Python 3.2 and now issues a deprecation warning beginning in Python 3.8.  This adds a definition of `assertRaisesRegex` to the pyutilib unittest wrapper in Python 2.

## Changes proposed in this PR:
- define `assertRaisesRegex` in Python 2.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
