### PR TITLE
ConfigBlock set_value should use __setitem__

### DIFF
--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -1022,7 +1022,7 @@ class ConfigBlock(ConfigBase):
             for key in self._decl_order:
                 if key in _decl_map:
                     #print "Setting", key, " = ", value
-                    self._data[key].set_value(value[_decl_map[key]])
+                    self[key] = value[_decl_map[key]]
             # implicit data is declared at the end (in sorted order)
             for key in sorted(_implicit):
                 self.add(key, value[key])


### PR DESCRIPTION
## Summary/Motivation:
I have a need to inherit from `ConfigBlock` and override `__setitem__`. Currently, `set_value` provides a way to bypass `__setitem__`. This PR updates `set_value` to use `__setitem__`.


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
