### PR TITLE
Remove pyutilib namespace package; defer TPL import tests

### DIFF
--- a/pyutilib/__init__.py
+++ b/pyutilib/__init__.py
@@ -7,10 +7,3 @@
 #  the U.S. Government retains certain rights in this software.
 #  _________________________________________________________________________
 #
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/pyutilib/component/__init__.py
+++ b/pyutilib/component/__init__.py
@@ -7,10 +7,3 @@
 #  the U.S. Government retains certain rights in this software.
 #  _________________________________________________________________________
 #
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/pyutilib/component/__init__.py
+++ b/pyutilib/component/__init__.py
@@ -7,3 +7,19 @@
 #  the U.S. Government retains certain rights in this software.
 #  _________________________________________________________________________
 #
+from . import core
+
+#
+# Import the 'pyutilib.component' plugins
+#
+core.PluginGlobals.add_env("pca")
+
+from . import config
+from . import executables
+from . import loader
+from . import app
+
+#
+# Remove the "pca" environment as the default
+#
+core.PluginGlobals.pop_env()

--- a/pyutilib/component/app/__init__.py
+++ b/pyutilib/component/app/__init__.py
@@ -11,4 +11,4 @@ The pyutilib.component.app package defines application interfaces that
 simplify the use of the PyUtilib Component Architecture.
 """
 
-from pyutilib.component.app.simple import SimpleApplication
+from .simple import SimpleApplication

--- a/pyutilib/component/core/__init__.py
+++ b/pyutilib/component/core/__init__.py
@@ -44,22 +44,10 @@ class IgnorePluginPlugins(SingletonPlugin):
 #
 # Import the 'pyutilib.component' plugins
 #
-try:
-    import pkg_resources
-    #
-    # Load modules associated with Plugins that are defined in
-    # EGG files.
-    #
-    for entrypoint in pkg_resources.iter_entry_points('pyutilib.component'):
-        plugin_class = entrypoint.load()
-        # print "Loading plugins... (%s)" % entrypoint
-except ImportError:
-    pass
-except Exception:
-    import sys
-    err = sys.exc_info()[1]
-    from sys import stderr as SE
-    SE.write("Error loading 'pyutilib.component' entry points: '%s'\n" % err)
+import pyutilib.component.app as _app
+import pyutilib.component.config as _config
+import pyutilib.component.executables as _executables
+import pyutilib.component.loader as _loader
 
 #
 # Remove the "pca" environment as the default

--- a/pyutilib/component/core/__init__.py
+++ b/pyutilib/component/core/__init__.py
@@ -19,19 +19,18 @@ NOTE: The PCA does not rely on any other part of PyUtilib.  Consequently,
 this package can be independently used in other projects.
 """
 
-from pyutilib.component.core.core import Plugin, implements, Interface, CreatePluginFactory, \
-           PluginMeta, alias, ExtensionPoint, SingletonPlugin, \
-           PluginFactory, PluginError, PluginGlobals, with_metaclass, \
-           IPluginLoader, IPluginLoadPath, IIgnorePluginWhenLoading, \
-           IOptionDataProvider, PluginEnvironment
-
-PluginGlobals.add_env("pca")
+from pyutilib.component.core.core import (
+    Plugin, implements, Interface, CreatePluginFactory,
+    PluginMeta, alias, ExtensionPoint, SingletonPlugin,
+    PluginFactory, PluginError, PluginGlobals, with_metaclass,
+    IPluginLoader, IPluginLoadPath, IIgnorePluginWhenLoading,
+    IOptionDataProvider, PluginEnvironment
+)
 
 #
 # This declaration is here because this is a convenient place where
 # all symbols in this module have been defined.
 #
-
 
 class IgnorePluginPlugins(SingletonPlugin):
     """Ignore plugins from the pyutilib.component module"""
@@ -40,16 +39,3 @@ class IgnorePluginPlugins(SingletonPlugin):
 
     def ignore(self, name):
         return name in globals()
-
-#
-# Import the 'pyutilib.component' plugins
-#
-import pyutilib.component.app as _app
-import pyutilib.component.config as _config
-import pyutilib.component.executables as _executables
-import pyutilib.component.loader as _loader
-
-#
-# Remove the "pca" environment as the default
-#
-PluginGlobals.pop_env()

--- a/pyutilib/component/loader/plugin_eggLoader.py
+++ b/pyutilib/component/loader/plugin_eggLoader.py
@@ -18,26 +18,28 @@ import logging
 from pyutilib.component.config import ManagedPlugin
 from pyutilib.component.core import implements, ExtensionPoint, IPluginLoader
 
-try:
-    if not 'pkg_resources' in sys.modules:
-        #
-        # Avoid a re-import, which causes setup.py warnings...
-        #
-        import pkg_resources
-    from pkg_resources import working_set, DistributionNotFound, VersionConflict, UnknownExtra, Environment
-    pkg_resources_avail = True
-
-    def pkg_environment(path):
-        return Environment(path)
-except ImportError:
-
-    def pkg_environment(path):
-        return None
-
-    pkg_resources_avail = False
-
 logger = logging.getLogger('pyutilib.component.core.pca')
+pkg_resources_avail = None
 
+def _check_pkg_resources():
+    global pkg_resources_avail
+    global pkg_resources
+    try:
+        if 'pkg_resources' not in sys.modules:
+            #
+            # Avoid a re-import, which causes setup.py warnings...
+            #
+            import pkg_resources
+        else:
+            pkg_resources = sys.modules['pkg_resources']
+        pkg_resources_avail = True
+    except ImportError:
+        pkg_resources_avail = False
+
+def pkg_environment(path):
+    if pkg_resources_avail is None:
+        _check_pkg_resources()
+    return pkg_resources.Environment(path) if pkg_resources_avail else None
 
 class EggLoader(ManagedPlugin):
     """
@@ -58,6 +60,8 @@ class EggLoader(ManagedPlugin):
             kwds['name'] = "EggLoader." + kwds['namespace']
         super(EggLoader, self).__init__(**kwds)
         self.entry_point_name = kwds['namespace'] + ".plugins"
+        if pkg_resources_avail is None:
+            _check_pkg_resources()
         if not pkg_resources_avail:
             logger.warning(
                 'A dummy EggLoader service is being constructed, because the pkg_resources package is not available on this machine.')
@@ -71,9 +75,11 @@ class EggLoader(ManagedPlugin):
                     'The EggLoader service is terminating early because the pkg_resources package is not available on this machine.')
             return
 
+        working_set = pkg_resources.working_set
+
         env.log.info('BEGIN -  Loading plugins with an EggLoader service')
         distributions, errors = working_set.find_plugins(
-            pkg_environment(search_path))
+            pkg_resources.Environment(search_path))
         for dist in distributions:
             if name_re.match(str(dist)):
                 if generate_debug_messages:
@@ -87,14 +93,14 @@ class EggLoader(ManagedPlugin):
 
         def _log_error(item, e):
             gen_debug = __debug__ and env.log.isEnabledFor(logging.DEBUG)
-            if isinstance(e, DistributionNotFound):
+            if isinstance(e, pkg_resources.DistributionNotFound):
                 if gen_debug:
                     env.log.debug('Skipping "%s": ("%s" not found)', item, e)
-            elif isinstance(e, VersionConflict):
+            elif isinstance(e, pkg_resources.VersionConflict):
                 if gen_debug:
                     env.log.debug('Skipping "%s": (version conflict "%s")',
                                   item, e)
-            elif isinstance(e, UnknownExtra):
+            elif isinstance(e, pkg_resources.UnknownExtra):
                 env.log.error('Skipping "%s": (unknown extra "%s")', item, e)
             elif isinstance(e, ImportError):
                 env.log.error('Skipping "%s": (can\'t import "%s")', item, e)
@@ -110,8 +116,10 @@ class EggLoader(ManagedPlugin):
                               entry.dist.location)
             try:
                 entry.load(require=True)
-            except (ImportError, DistributionNotFound, VersionConflict,
-                    UnknownExtra):
+            except (ImportError,
+                    pkg_resources.DistributionNotFound,
+                    pkg_resources.VersionConflict,
+                    pkg_resources.UnknownExtra):
                 e = sys.exc_info()[1]
                 _log_error(entry, e)
             else:

--- a/pyutilib/excel/spreadsheet.py
+++ b/pyutilib/excel/spreadsheet.py
@@ -21,9 +21,9 @@ class Interfaces(object):
     singleton = None
 
     def __new__(cls):
-        if _Interfaces.singleton is None:
-            _Interfaces.singleton = super(_Interfaces,cls).__new__(cls)
-        return _Interfaces.singleton
+        if Interfaces.singleton is None:
+            Interfaces.singleton = super(Interfaces,cls).__new__(cls)
+        return Interfaces.singleton
 
     def __init__(self):
         self.options = ['xlrd','win32com','openpyxl']
@@ -73,7 +73,7 @@ class ExcelSpreadsheet(ExcelSpreadsheet_base):
         # class instances here.
         #
         ctype = kwds.pop('ctype', None)
-        interfaces = _Interfaces()
+        interfaces = Interfaces()
 
         if not ctype:
             for interface in interfaces.options:

--- a/setup.py
+++ b/setup.py
@@ -92,14 +92,8 @@ setup(name="PyUtilib",
         'Topic :: Utilities'],
       packages=packages,
       keywords=['utility'],
-      namespace_packages=['pyutilib', 'pyutilib.component'],
       install_requires=requires,
       entry_points="""
-        [pyutilib.component]
-        component.app = pyutilib.component.app
-        component.config = pyutilib.component.config
-        component.executables = pyutilib.component.executables
-        component.loader = pyutilib.component.loader
         [nose.plugins.0.10]
         nose.testdata = pyutilib.th.nose_testdata:TestData
         nose.forcedgc = pyutilib.th.nose_gc:ForcedGC


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This PR does two things:
  - Removes the use of namespace packages from pyutilib.  After we consolidated the bulk of PyUtilib into a single repository, there aren't (maintained) pyutilib capabilities outside of this repository.  Removing the namespace packaging simplifies several things (including plugin imports)
  - Reworks how optional dependent libraries are imported so that many optional dependencies (notably `pkg_resources` and `openpyxl`) are only imported "on demand".  This *significantly* speeds up importing pyutilib.

## Changes proposed in this PR:
- remove namespace packages `pyutilib` and `pyutilib.component`
- rework optional dependency imports

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
