### PR TITLE
Adding Py2 compatibility shim for assertRegex

### DIFF
--- a/pyutilib/th/pyunit.py
+++ b/pyutilib/th/pyunit.py
@@ -271,6 +271,7 @@ class TestCase(unittest.TestCase):
         # Compatibility shim: assertRaisesRegexp was renamed to
         # assertRaisesRegex in Python 3.2
         assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+        assertRegex = unittest.TestCase.assertRegexpMatches
 
     def __init__(self, methodName='runTest'):
         unittest.TestCase.__init__(self, methodName)


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This adds a simple compatibility ship for `assertRegex` for Python 2/3 compatibility.

## Changes proposed in this PR:
- add `assertRegex` to `pyutilib.th` in Python 2

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
