### PR TITLE
Switch spreadsheet interface to load dependencies on demand

### DIFF
--- a/pyutilib/excel/spreadsheet.py
+++ b/pyutilib/excel/spreadsheet.py
@@ -90,6 +90,6 @@ class ExcelSpreadsheet(ExcelSpreadsheet_base):
                 % (ctype, interfaces.options,))
 
         if not interfaces[ctype].available:
-            raise ImportError("Excel interface %s is not aailable" % (ctype,))
+            raise ImportError("Excel interface %s is not available" % (ctype,))
 
         return interfaces[ctype].module(*args, **kwds)

--- a/pyutilib/excel/spreadsheet.py
+++ b/pyutilib/excel/spreadsheet.py
@@ -10,58 +10,56 @@
 __all__ = ['ExcelSpreadsheet']
 
 import pyutilib.common
-
-#
-# Attempt to import openpyxl
-#
-try:
-    import openpyxl
-    _openpyxl = True
-except:
-    _openpyxl = False
-#
-# Attempt to import xlrd
-#
-try:
-    import xlrd
-    _xlrd = True
-except:
-    _xlrd = False
-#
-# Attempt to import win32com stuff. 
-#
-try:
-    from win32com.client.dynamic import Dispatch
-    from pythoncom import CoInitialize, CoUninitialize
-    from pythoncom import CoInitialize, CoUninitialize, com_error
-    _win32com = True
-except:
-    _win32com = False  #pragma:nocover
-
 from pyutilib.excel.base import ExcelSpreadsheet_base
 
-if _win32com:
-    from pyutilib.excel.spreadsheet_win32com import ExcelSpreadsheet_win32com
-else:
+class _Interface(object):
+    def __init__(self, available, module):
+        self.available = available
+        self.module = module
 
-    class ExcelSpreadsheet_win32com(ExcelSpreadsheet_base):
-        pass
+class Interfaces(object):
+    singleton = None
 
+    def __new__(cls):
+        if Interfaces.singleton is None:
+            Interfaces.singleton = super(Interfaces,cls).__new__(cls)
+        return Interfaces.singleton
 
-if _openpyxl:
-    from pyutilib.excel.spreadsheet_openpyxl import ExcelSpreadsheet_openpyxl
-else:
+    def __init__(self):
+        self.options = ['xlrd','win32com','openpyxl']
+        self._modules = {}
 
-    class ExcelSpreadsheet_openpyxl(ExcelSpreadsheet_base):
-        pass
+        try:
+            import xlrd
+            from pyutilib.excel.spreadsheet_xlrd import (
+                ExcelSpreadsheet_xlrd as module
+            )
+            self._modules['xlrd'] = _Interface(True, module)
+        except ImportError:
+            self._modules['xlrd'] = _Interface(False, None)
 
+        try:
+            from win32com.client.dynamic import Dispatch
+            from pythoncom import CoInitialize, CoUninitialize
+            from pythoncom import CoInitialize, CoUninitialize, com_error
+            from pyutilib.excel.spreadsheet_win32com import (
+                ExcelSpreadsheet_win32com as module
+            )
+            self._modules['win32com'] = _Interface(True, module)
+        except ImportError:
+            self._modules['win32com'] = _Interface(False, None)
 
-if _xlrd:
-    from pyutilib.excel.spreadsheet_xlrd import ExcelSpreadsheet_xlrd
-else:
+        try:
+            import openpyxl
+            from pyutilib.excel.spreadsheet_openpyxl import (
+                ExcelSpreadsheet_openpyxl as module
+            )
+            self._modules['openpyxl'] = _Interface(True, module)
+        except ImportError:
+            self._modules['openpyxl'] = _Interface(False, None)
 
-    class ExcelSpreadsheet_xlrd(ExcelSpreadsheet_base):
-        pass
+    def __getitem__(self, item):
+        return self._modules[item]
 
 
 class ExcelSpreadsheet(ExcelSpreadsheet_base):
@@ -75,18 +73,23 @@ class ExcelSpreadsheet(ExcelSpreadsheet_base):
         # class instances here.
         #
         ctype = kwds.pop('ctype', None)
-        if ctype == 'xlrd':
-            return ExcelSpreadsheet_xlrd(*args, **kwds)
-        if ctype == 'win32com':
-            return ExcelSpreadsheet_win32com(*args, **kwds)
-        if ctype == 'openpyxl':
-            return ExcelSpreadsheet_openpyxl(*args, **kwds)
-        #
-        if _xlrd:
-            return ExcelSpreadsheet_xlrd(*args, **kwds)
-        if _win32com:
-            return ExcelSpreadsheet_win32com(*args, **kwds)
-        if _openpyxl:
-            return ExcelSpreadsheet_openpyxl(*args, **kwds)
-        #
-        return super(ExcelSpreadsheet, cls).__new__(cls)
+        interfaces = Interfaces()
+
+        if not ctype:
+            for interface in interfaces.options:
+                if interfaces[interface].available:
+                    ctype = interface
+                    break
+            if not ctype:
+                raise RuntimeError("No excel interface (from %s) available"
+                                   % (interfaces.options,))
+
+        if ctype not in interfaces.options:
+            raise RuntimeError(
+                "Excel interface %s not in known interfaces (%s)"
+                % (ctype, interfaces.options,))
+
+        if not interfaces[ctype].available:
+            raise ImportError("Excel interface %s is not aailable" % (ctype,))
+
+        return interfaces[ctype].module(*args, **kwds)


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
Reworks how optional dependent libraries are imported so that many optional dependencies (notably `pkg_resources` and `openpyxl`) are only imported "on demand". This significantly speeds up importing pyutilib.

## Changes proposed in this PR:
- rework optional dependency imports

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
