### PR TITLE
Additional use of deferred imports to speed up pyutilib import

### DIFF
--- a/pyutilib/component/config/plugin_ConfigParser.py
+++ b/pyutilib/component/config/plugin_ConfigParser.py
@@ -13,10 +13,6 @@ __all__ = ['Configuration_ConfigParser']
 import sys
 import os.path
 try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
-try:
     from ordereddict import OrderedDict
 except:
     OrderedDict = dict
@@ -25,11 +21,16 @@ from pyutilib.component.config.configuration import ConfigurationError, IConfigu
 from pyutilib.component.config.managed_plugin import ManagedSingletonPlugin
 from pyutilib.component.config.options import declare_option
 
-#
-# Force the config file option manager to be case sensitive
-#
-ConfigParser.RawConfigParser.optionxform = str
-
+def _configParser(**kwds):
+    try:
+        import ConfigParser
+    except ImportError:
+        import configparser as ConfigParser
+    #
+    # Force the config file option manager to be case sensitive
+    #
+    ConfigParser.RawConfigParser.optionxform = str
+    return ConfigParser.ConfigParser(**kwds)
 
 class Configuration_ConfigParser(ManagedSingletonPlugin):
     """A configuration parser that uses the ConfigParser package."""
@@ -42,7 +43,7 @@ class Configuration_ConfigParser(ManagedSingletonPlugin):
 
     def load(self, filename):
         """Returns a list of tuples: [ (section,option,value) ]"""
-        parser = ConfigParser.ConfigParser()
+        parser = _configParser()
         if not os.path.exists(filename):
             raise ConfigurationError("File " + filename + " does not exist!")
         parser.read(filename)
@@ -58,9 +59,9 @@ class Configuration_ConfigParser(ManagedSingletonPlugin):
     def save(self, filename, config, header=None):
         """Save configuration information to the specified file."""
         if sys.version_info[:2] == (2, 6):
-            parser = ConfigParser.ConfigParser(dict_type=OrderedDict)
+            parser = _configParser(dict_type=OrderedDict)
         else:
-            parser = ConfigParser.ConfigParser()
+            parser = _configParser()
         for (section, option, value) in config:
             if not parser.has_section(section):
                 parser.add_section(section)

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -16,15 +16,19 @@ import pickle
 import six
 from six.moves import xrange
 
-try:
-    from yaml import dump
-except ImportError:
-    #dump = lambda x,**y: str(x)
-    # YAML uses lowercase True/False
-    def dump(x, **args):
-        if type(x) is bool:
-            return str(x).lower()
-        return str(x)
+def _dump(*args, **kwds):
+    try:
+        from yaml import dump
+    except ImportError:
+        #dump = lambda x,**y: str(x)
+        # YAML uses lowercase True/False
+        def dump(x, **args):
+            if type(x) is bool:
+                return str(x).lower()
+            return str(x)
+    assert '_dump' in globals()
+    globals()['_dump'] = dump
+    return dump(*args, **kwds)
 
 try:
     import argparse
@@ -77,7 +81,7 @@ def _value2string(prefix, value, obj):
             _data = value._data if value is obj else value
             if getattr(_builtins, _data.__class__.__name__, None
                    ) is not None:
-                _str += dump(_data, default_flow_style=True).rstrip()
+                _str += _dump(_data, default_flow_style=True).rstrip()
                 if _str.endswith("..."):
                     _str = _str[:-3].rstrip()
             else:
@@ -91,7 +95,7 @@ def _value2yaml(prefix, value, obj):
     if value is not None:
         try:
             _data = value._data if value is obj else value
-            _str += dump(_data, default_flow_style=True).rstrip()
+            _str += _dump(_data, default_flow_style=True).rstrip()
             if _str.endswith("..."):
                 _str = _str[:-3].rstrip()
         except:

--- a/pyutilib/misc/pyyaml_util.py
+++ b/pyutilib/misc/pyyaml_util.py
@@ -25,16 +25,7 @@ try:
     from StringIO import StringIO
 except:
     from io import StringIO
-try:
-    import json
-    json_available = True
-except:
-    json_available = False
-try:
-    import yaml
-    yaml_available = True  #pragma:nocover
-except:  #pragma:nocover
-    yaml_available = False  #pragma:nocover
+
 from pyutilib.misc.comparison import open_possibly_compressed_file
 
 
@@ -153,11 +144,13 @@ def extract_subtext(stream, begin_str='', end_str=None, comment='#'):
 
 
 def load_yaml(str):
+    import yaml
     istream = StringIO(str)
     return yaml.load(istream, Loader=yaml.SafeLoader)
 
 
 def load_json(str):
+    import json
 
     def _to_list(data):
         ans = []
@@ -298,18 +291,19 @@ def compare_strings(baseline,
                     tolerance=0.0,
                     exact=True,
                     using_yaml=True):
-    if using_yaml and not yaml_available:  #pragma:nocover
-        raise IOError(
-            "Cannot compare YAML strings because YAML is not available")
-    if not using_yaml and not json_available:
-        raise IOError(
-            "Cannot compare JSON strings because JSON is not available")
     if using_yaml:
-        baseline_repn = load_yaml(baseline)
-        output_repn = load_yaml(output)
+        try:
+            baseline_repn = load_yaml(baseline)
+            output_repn = load_yaml(output)
+        except ImportError:
+            raise IOError(
+                "Cannot compare YAML strings because YAML is not available")
     else:
         try:
             baseline_repn = load_json(baseline)
+        except ImportError:
+            raise IOError(
+                "Cannot compare JSON strings because JSON is not available")
         except Exception:
             print("Problem parsing JSON baseline")
             print(baseline)


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This makes additional use of deferred imports to avoid importing dependencies until the point where the dependencies are actually needed.  This helps speed up the import of pyutilib, and by extension, dependent projects.

## Changes proposed in this PR:
- defer the import of `ConfigParser` and `yaml` modules

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
