### PR TITLE
Updates to pyutilib.misc.config

### DIFF
--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -942,6 +942,20 @@ class ConfigBlock(ConfigBase):
         self._declared.add(name)
         return ans
 
+    def inherit_from(self, other, skip=None):
+        if not isinstance(other, ConfigBlock):
+            raise ValueError(
+                "ConfigBlock.inherit_from() only accepts other ConfigBlocks")
+        # Note that we duplicate ["other()"] other so that this
+        # ConfigBlock's entries are independent of the other's
+        for key in other.iterkeys():
+            if skip and key in skip:
+                continue
+            if key in self:
+                raise ValueError("ConfigBlock.inherit_from passed a block "
+                                 "with a duplicate field, %s" % (key,))
+            self.declare(key, other._data[key]())
+
     def add(self, name, config):
         if not self._implicit_declaration:
             raise ValueError("Key '%s' not defined in Config Block '%s'"

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -831,12 +831,13 @@ class ConfigBase(object):
             elif item_end:
                 os.write(indent + item_end)
         while level:
-            indent = indent[:-1 * indent_spacing]
             _last = level.pop()
-            if '%s' in block_end:
-                os.write(indent + block_end % _last.name())
-            else:
-                os.write(indent + block_end)
+            if _last is not None:
+                indent = indent[:-1 * indent_spacing]
+                if '%s' in block_end:
+                    os.write(indent + block_end % _last.name())
+                else:
+                    os.write(indent + block_end)
         return os.getvalue()
 
     def user_values(self):

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -445,7 +445,8 @@ group, subparser, or (subparser, group)."""
                         del parsed_args.__dict__[_dest]
         return parsed_args
 
-    def display(self, content_filter=None, indent_spacing=2, ostream=None):
+    def display(self, content_filter=None, indent_spacing=2, ostream=None,
+                visibility=None):
         if content_filter not in ConfigBlock.content_filters:
             raise ValueError("unknown content filter '%s'; valid values are %s"
                              % (content_filter, ConfigBlock.content_filters))
@@ -454,13 +455,12 @@ group, subparser, or (subparser, group)."""
         if ostream is None:
             ostream=stdout
 
-        for level, prefix, value, obj in self._data_collector(0, ""):
+        for lvl, prefix, value, obj in self._data_collector(0, "", visibility):
             if content_filter == 'userdata' and not obj._userSet:
                 continue
 
             _str = _value2string(prefix, value, obj)
-            _blocks[level:] = [
-                ' ' * indent_spacing * level + _str + "\n",]
+            _blocks[lvl:] = [' ' * indent_spacing * lvl + _str + "\n",]
 
             for i, v in enumerate(_blocks):
                 if v is not None:

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -37,7 +37,7 @@ try:
 except ImportError:
     import __builtin__ as _builtins
 
-__all__ = ('ConfigBlock', 'ConfigList', 'ConfigValue')
+__all__ = ('ConfigDict', 'ConfigBlock', 'ConfigList', 'ConfigValue')
 
 logger = logging.getLogger('pyutilib.misc.config')
 

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -23,30 +23,35 @@ values for those entries, and retrieve the current values:
 
 .. doctest::
     :hide:
+
     >>> import argparse
     >>> from pyutilib.misc.config import (
     ...     ConfigDict, ConfigList, ConfigValue, In,
     ... )
 
 .. doctest::
+
     >>> config = ConfigDict()
     >>> config.declare('filename', ConfigValue(
     ...     default=None,
     ...     domain=str,
     ...     description="Input file name",
     ... ))
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare("bound tolerance", ConfigValue(
     ...     default=1E-5,
     ...     domain=float,
     ...     description="Bound tolerance",
     ...     doc="Relative tolerance for bound feasibility checks"
     ... ))
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare("iteration limit", ConfigValue(
     ...     default=30,
     ...     domain=int,
     ...     description="Iteration limit",
     ...     doc="Number of maximum iterations in the decomposition methods"
     ... ))
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config['filename'] = 'tmp.txt'
     >>> print(config['filename'])
     tmp.txt
@@ -58,6 +63,7 @@ attributes (with spaces in the declaration names replaced by
 underscores):
 
 .. doctest::
+
     >>> print(config.filename)
     tmp.txt
     >>> print(config.iteration_limit)
@@ -75,6 +81,7 @@ information).  This allows client code to accept a very flexible set of
 inputs without "cluttering" the code with input validation:
 
 .. doctest::
+
     >>> config.iteration_limit = 35.5
     >>> print(config.iteration_limit)
     35
@@ -91,6 +98,7 @@ feature allows ConfigDicts to cleanly support the configuration of
 derived objects.  Consider the following example:
 
 .. doctest::
+
     >>> class Base(object):
     ...     CONFIG = ConfigDict()
     ...     CONFIG.declare('filename', ConfigValue(
@@ -108,9 +116,9 @@ derived objects.  Consider the following example:
     ...         domain=str,
     ...     ))
     ...
-    >>> Base(filename='foo.txt')
+    >>> tmp = Base(filename='foo.txt')
     filename: foo.txt
-    >>> Derived(pattern='.*warning')
+    >>> tmp = Derived(pattern='.*warning')
     filename: input.txt
     pattern: .*warning
 
@@ -134,6 +142,7 @@ creating copies of the class's configuration for both specific instances
 and for use by each `solve()` call:
 
 .. doctest::
+
     >>> class Solver(object):
     ...     CONFIG = ConfigDict()
     ...     CONFIG.declare('iterlim', ConfigValue(
@@ -169,34 +178,41 @@ declaration simpler, the `declare` method returns the declared Config
 object so that the argument declaration can be done inline:
 
 .. doctest::
+
     >>> config = ConfigDict()
     >>> config.declare('iterlim', ConfigValue(
     ...     domain=int,
     ...     default=100,
     ...     description="iteration limit",
     ... )).declare_as_argument()
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare('lbfgs', ConfigValue(
     ...     domain=bool,
     ...     description="use limited memory BFGS update",
     ... )).declare_as_argument()
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare('linesearch', ConfigValue(
     ...     domain=bool,
     ...     default=True,
     ...     description="use line search",
     ... )).declare_as_argument()
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare('relative tolerance', ConfigValue(
     ...     domain=float,
     ...     description="relative convergence tolerance",
     ... )).declare_as_argument('--reltol', '-r', group='Tolerances')
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare('absolute tolerance', ConfigValue(
     ...     domain=float,
     ...     description="absolute convergence tolerance",
     ... )).declare_as_argument('--abstol', '-a', group='Tolerances')
+    <pyutilib.misc.config.ConfigValue object at ...>
 
 The ConfigDict can then be used to initialize (or augment) an argparse
 ArgumentParser object:
 
 .. doctest::
+
     >>> parser = argparse.ArgumentParser("tester")
     >>> config.initialize_argparse(parser)
 
@@ -205,6 +221,7 @@ Key information from the ConfigDict is automatically transferred over
 to the ArgumentParser object:
 
 .. doctest::
+
     >>> print(parser.format_help())
     usage: tester [-h] [--iterlim INT] [--lbfgs] [--disable-linesearch]
                   [--reltol FLOAT] [--abstol FLOAT]
@@ -220,12 +237,14 @@ to the ArgumentParser object:
                             relative convergence tolerance
       --abstol FLOAT, -a FLOAT
                             absolute convergence tolerance
+    <BLANKLINE>
 
 Parsed arguments can then be imported back into the ConfigDict:
 
 .. doctest::
+
     >>> args=parser.parse_args(['--lbfgs', '--reltol', '0.1', '-a', '0.2'])
-    >>> config.import_argparse(args)
+    >>> args = config.import_argparse(args)
     >>> config.display()
     iterlim: 100
     lbfgs: true
@@ -243,6 +262,7 @@ that a user explicitly set (`user_values`) and the items that were set
 but never retrieved (`unused_user_values`):
 
 .. doctest::
+
     >>> print([val.name() for val in config.user_values()])
     ['lbfgs', 'relative tolerance', 'absolute tolerance']
     >>> print(config.relative_tolerance)
@@ -262,6 +282,7 @@ simular to `display`, but also includes the description fields as
 formatted comments.
 
 .. doctest::
+
     >>> solver_config = config
     >>> config = ConfigDict()
     >>> config.declare('output', ConfigValue(
@@ -269,6 +290,7 @@ formatted comments.
     ...     domain=str,
     ...     description='output results filename'
     ... ))
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare('verbose', ConfigValue(
     ...     default=0,
     ...     domain=int,
@@ -277,10 +299,12 @@ formatted comments.
     ...     'warnings and errors.  Larger integer values will produce '
     ...     'additional log messages.',
     ... ))
+    <pyutilib.misc.config.ConfigValue object at ...>
     >>> config.declare('solvers', ConfigList(
     ...     domain=solver_config,
     ...     description='list of solvers to apply',
     ... ))
+    <pyutilib.misc.config.ConfigList object at ...>
     >>> config.display()
     output: results.yml
     verbose: 0
@@ -289,6 +313,7 @@ formatted comments.
     output: results.yml  # output results filename
     verbose: 0           # output verbosity
     solvers: []          # list of solvers to apply
+    <BLANKLINE>
 
 It is important to note that both methods document the current state of
 the configuration object.  So, in the example above, since the `solvers`
@@ -297,6 +322,7 @@ list.  Of course, if you add a value to the list, then the data will be
 output:
 
 .. doctest::
+
     >>> tmp = config()
     >>> tmp.solvers.append({})
     >>> tmp.display()
@@ -319,6 +345,7 @@ output:
         linesearch: true         # use line search
         relative tolerance: 0.1  # relative convergence tolerance
         absolute tolerance: 0.2  # absolute convergence tolerance
+    <BLANKLINE>
 
 The third method (:py:meth:`generate_documentation`) behaves
 differently.  This method is designed to generate reference
@@ -330,33 +357,35 @@ values.  The documentation can be configured through optional arguments.
 The defaults generate LaTeX documentation:
 
 .. doctest::
+
     >>> print(config.generate_documentation())
-    \begin{description}[topsep=0pt,parsep=0.5em,itemsep=-0.4em]
-      \item[{output}]\hfill
-        \\output results filename
-      \item[{verbose}]\hfill
-        \\This sets the system verbosity.  The default (0) only logs warnings and
+    \\begin{description}[topsep=0pt,parsep=0.5em,itemsep=-0.4em]
+      \\item[{output}]\hfill
+        \\\\output results filename
+      \\item[{verbose}]\hfill
+        \\\\This sets the system verbosity.  The default (0) only logs warnings and
         errors.  Larger integer values will produce additional log messages.
-      \item[{solvers}]\hfill
-        \\list of solvers to apply
-      \begin{description}[topsep=0pt,parsep=0.5em,itemsep=-0.4em]
-        \item[{iterlim}]\hfill
-          \\iteration limit
-        \item[{lbfgs}]\hfill
-          \\use limited memory BFGS update
-        \item[{linesearch}]\hfill
-          \\use line search
-        \item[{relative tolerance}]\hfill
-          \\relative convergence tolerance
-        \item[{absolute tolerance}]\hfill
-          \\absolute convergence tolerance
-      \end{description}
-    \end{description}
+      \\item[{solvers}]\hfill
+        \\\\list of solvers to apply
+      \\begin{description}[topsep=0pt,parsep=0.5em,itemsep=-0.4em]
+        \\item[{iterlim}]\hfill
+          \\\\iteration limit
+        \\item[{lbfgs}]\hfill
+          \\\\use limited memory BFGS update
+        \\item[{linesearch}]\hfill
+          \\\\use line search
+        \\item[{relative tolerance}]\hfill
+          \\\\relative convergence tolerance
+        \\item[{absolute tolerance}]\hfill
+          \\\\absolute convergence tolerance
+      \\end{description}
+    \\end{description}
+    <BLANKLINE>
 
 """
 
 import re
-from sys import exc_info, stdout
+import sys
 from textwrap import wrap
 import logging
 import pickle
@@ -486,7 +515,7 @@ def _picklable(field,obj):
         # either: exceeding recursion depth raises a RuntimeError
         # through 3.4, then switches to a RecursionError (a derivative
         # of RuntimeError).
-        if isinstance(exc_info()[0], RuntimeError):
+        if isinstance(sys.exc_info()[0], RuntimeError):
             raise
         _picklable.known[ftype] = False
         return _UnpickleableDomain(obj)
@@ -654,7 +683,7 @@ class ConfigBase(object):
                 else:
                     return self._domain()
             except:
-                err = exc_info()[1]
+                err = sys.exc_info()[1]
                 if hasattr(self._domain, '__name__'):
                     _dom = self._domain.__name__
                 else:
@@ -807,7 +836,7 @@ class ConfigBase(object):
 
         _blocks = []
         if ostream is None:
-            ostream=stdout
+            ostream=sys.stdout
 
         for lvl, prefix, value, obj in self._data_collector(0, "", visibility):
             if content_filter == 'userdata' and not obj._userSet:

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -942,17 +942,17 @@ class ConfigBlock(ConfigBase):
         self._declared.add(name)
         return ans
 
-    def inherit_from(self, other, skip=None):
+    def declare_from(self, other, skip=None):
         if not isinstance(other, ConfigBlock):
             raise ValueError(
-                "ConfigBlock.inherit_from() only accepts other ConfigBlocks")
+                "ConfigBlock.declare_from() only accepts other ConfigBlocks")
         # Note that we duplicate ["other()"] other so that this
         # ConfigBlock's entries are independent of the other's
         for key in other.iterkeys():
             if skip and key in skip:
                 continue
             if key in self:
-                raise ValueError("ConfigBlock.inherit_from passed a block "
+                raise ValueError("ConfigBlock.declare_from passed a block "
                                  "with a duplicate field, %s" % (key,))
             self.declare(key, other._data[key]())
 

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -978,7 +978,7 @@ class ConfigBlock(ConfigBase):
         return dict((name, config.value(accessValue))
                     for name, config in six.iteritems(self._data))
 
-    def set_value(self, value):
+    def set_value(self, value, skip_implicit=False):
         if value is None:
             return self
         if (type(value) is not dict) and \
@@ -1001,7 +1001,9 @@ class ConfigBlock(ConfigBase):
                 if _key in self._data:
                     _decl_map[str(_key)] = key
                 else:
-                    if self._implicit_declaration:
+                    if skip_implicit:
+                        pass
+                    elif self._implicit_declaration:
                         _implicit.append(key)
                     else:
                         raise ValueError(

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -7,13 +7,13 @@
 #  the U.S. Government retains certain rights in this software.
 #  _________________________________________________________________________
 
-"""
-=================================
+"""=================================
 The PyUtilib Configuration System
 =================================
 
-The PyUtilib config system provides a set of three classes (ConfigDict,
-ConfigList, and ConfigValue) for managing and documenting structured
+The PyUtilib config system provides a set of three classes
+(:py:class:`ConfigDict`, :py:class:`ConfigList`, and
+:py:class:`ConfigValue`) for managing and documenting structured
 configuration information and user input.  The system is based around
 the ConfigValue class, which provides storage for a single configuration
 entry.  ConfigValue objects can be grouped using two containers
@@ -75,7 +75,7 @@ underscores):
     >>> print(config.iteration_limit)
     20
 
-All Config objects support a `domain` keyword that accepts a callable
+All Config objects support a ``domain`` keyword that accepts a callable
 object (type, function, or callable instance).  The domain callable
 should take data and map it onto the desired domain, optionally
 performing domain validation (see :py:class:`ConfigValue`,
@@ -95,7 +95,7 @@ Configuring class hierarchies
 =============================
 
 A feature of the Config system is that the core classes all implement
-`__call__`, and can themselves be used as `domain` values.  Beyond
+``__call__``, and can themselves be used as ``domain`` values.  Beyond
 providing domain verification for complex hierarchical structures, this
 feature allows ConfigDicts to cleanly support the configuration of
 derived objects.  Consider the following example:
@@ -125,24 +125,24 @@ derived objects.  Consider the following example:
     filename: input.txt
     pattern: .*warning
 
-Here, the base class `Base` declares a class-level attribute CONFIG as a
-ConfigDict containing a single entry (`filename`).  The derived class
-(`Derived`) then starts by making a copy of the base class' `CONFIG`,
+Here, the base class ``Base`` declares a class-level attribute CONFIG as a
+ConfigDict containing a single entry (``filename``).  The derived class
+(``Derived``) then starts by making a copy of the base class' ``CONFIG``,
 and then defines an additional entry (`pattern`).  Instances of the base
-class will still create `c` instances that only have the single
-`filename` entry, whereas instances of the derived class will have `c`
-instances with two entries: the `pattern` entry declared by the derived
-class, and the `filename` entry "inherited" from the base class.
+class will still create ``c`` instances that only have the single
+``filename`` entry, whereas instances of the derived class will have ``c``
+instances with two entries: the ``pattern`` entry declared by the derived
+class, and the ``filename`` entry "inherited" from the base class.
 
 An extension of this design pattern provides a clean approach for
 handling "ephemeral" instance options.  Consider an interface to an
-external "solver".  Our class implements a `solve()` method that takes a
+external "solver".  Our class implements a ``solve()`` method that takes a
 problem and sends it to the solver along with some solver configuration
 options.  We would like to be able to set those options "persistently"
 on instances of the interface class, but still override them
-"temporarily" for individual calls to `solve()`.  We implement this by
+"temporarily" for individual calls to ``solve()``.  We implement this by
 creating copies of the class's configuration for both specific instances
-and for use by each `solve()` call:
+and for use by each ``solve()`` call:
 
 .. doctest::
 
@@ -177,7 +177,7 @@ Interacting with argparse
 In addition to basic storage and retrieval, the Config system provides
 hooks to the argparse command-line argument parsing system.  Individual
 Config entries can be declared as argparse arguments.  To make
-declaration simpler, the `declare` method returns the declared Config
+declaration simpler, the :py:meth:`declare` method returns the declared Config
 object so that the argument declaration can be done inline:
 
 .. doctest::
@@ -261,8 +261,8 @@ Accessing user-specified values
 It is frequently useful to know which values a user explicitly set, and
 which values a user explicitly set, but have never been retrieved.  The
 configuration system provides two gemerator methods to return the items
-that a user explicitly set (`user_values`) and the items that were set
-but never retrieved (`unused_user_values`):
+that a user explicitly set (:py:meth:`user_values`) and the items that
+were set but never retrieved (:py:meth:`unused_user_values`):
 
 .. doctest::
 
@@ -277,11 +277,13 @@ Generating output & documentation
 =================================
 
 Configuration objects support three methods for generating output and
-documentation: `display()`, `generate_yaml_template()`, and
-`generate_documentation()`.  The simplest is `display()`, which prints
-out the current values of the configuration object (and if it is a
-container type, all of it's children).  `generate_yaml_template` is
-simular to `display`, but also includes the description fields as
+documentation: :py:meth:`display()`,
+:py:meth:`generate_yaml_template()`, and
+:py:meth:`generate_documentation()`.  The simplest is
+:py:meth:`display()`, which prints out the current values of the
+configuration object (and if it is a container type, all of it's
+children).  :py:meth:`generate_yaml_template` is simular to
+:py:meth:`display`, but also includes the description fields as
 formatted comments.
 
 .. doctest::


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This PR adds some long-overdue documentation for the ConfigValue / ConfigList / ConfigDict system.  As part of this, it resolved some bugs and begins the process to rename ConfigBlock to ConfigDict (both names are currently supported).  The documentation was confirmed to build and pass doctests (using the Pyomo Online Docs harness).

## Changes proposed in this PR:
- Rename `ConfigBlock` to `ConfigDict`
- Add `ConfigDict.declare_from()` method
- Resolve a bug involving `ConfigDict.set_value()` and `__getitem__` for derived `ConfigDict` classes
- Add a visibility option to `display()`
- Add lots of documentation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
