### PR TITLE
Remove scrutinizer badge, fix pypi badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Travis Build Status](https://travis-ci.org/PyUtilib/pyutilib.png?branch=master)](https://travis-ci.org/PyUtilib/pyutilib)
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/c8dh5o1blp0sycr6/branch/master?svg=true)](https://ci.appveyor.com/project/WilliamHart/pyutilib/branch/master)
 [![codecov.io](https://codecov.io/github/PyUtilib/pyutilib/coverage.svg?branch=master)](https://codecov.io/github/PyUtilib/pyutilib?branch=master)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/PyUtilib/pyutilib/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/PyUtilib/pyutilib/?branch=master)
 [![Depsy Software Impact](http://depsy.org/api/package/pypi/PyUtilib/badge.svg)](http://depsy.org/package/python/PyUtilib)
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 
@@ -17,7 +16,7 @@ PyUtilib is available under the BSD License.
 
 ### Installation
 
-#### PyPI [![PyPI](https://img.shields.io/pypi/v/pyutilib.svg?maxAge=2592000)]() 
+#### PyPI [![PyPI version](https://img.shields.io/pypi/v/pyutilib.svg?maxAge=3600)](https://pypi.org/project/PyUtilib/) [![PyPI downloads](https://img.shields.io/pypi/dm/pyutilib.svg?maxAge=21600)](https://pypistats.org/packages/pyutilib)
 
     pip install pyutilib
     


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This removes scrutinizer badge and fixes pypi badge links and cache expiration time.

## Changes proposed in this PR:
- Update README.md

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
