### PR TITLE
Adding an ImmutableConfigValue class

### DIFF
--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -1074,6 +1074,26 @@ class ImmutableConfigValue(ConfigValue):
 
 
 class MarkImmutable(object):
+    """
+    Mark instances of ConfigValue as immutable.
+
+    Parameters
+    ----------
+    config_value: ConfigValue
+        The ConfigValue instances that should be marked immutable. 
+        Note that multiple instances of ConfigValue can be passed.
+
+    Examples
+    --------
+    >>> config = ConfigBlock()
+    >>> config.declare('a', ConfigValue(default=1, domain=int))
+    >>> config.declare('b', ConfigValue(default=1, domain=int))
+    >>> locker = MarkImmutable(config.get('a'), config.get('b'))
+    
+    Now, config.a and config.b cannot be changed. To make them mutable again, 
+
+    >>> locker.release_lock()
+    """
     def __init__(self, *args):
         self._locked = list()
         try:

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -1072,6 +1072,17 @@ class ImmutableConfigValue(ConfigValue):
     def set_value(self, value):
         raise RuntimeError(str(self) + ' is currently immutable')
 
+    def reset(self):
+        try:
+            super(ImmutableConfigValue, self).set_value(self._default)
+        except:
+            if hasattr(self._default, '__call__'):
+                super(ImmutableConfigValue, self).set_value(self._default())
+            else:
+                raise
+        self._userAccessed = False
+        self._userSet = False
+
 
 class MarkImmutable(object):
     """

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -1068,6 +1068,53 @@ class ConfigValue(ConfigBase):
         yield (level, prefix, self, self)
 
 
+class ImmutableConfigValue(ConfigValue):
+    """
+    A config value that supports temporary immutability.
+
+
+    Parameters
+    ----------
+    default: optional
+        The default value that this ConfigValue will take if no value is
+        provided.
+
+    domain: callable, optional
+        The domain can be any callable that accepts a candidate value
+        and returns the value converted to the desired type, optionally
+        performing any data validation.  The result will be stored into
+        the ConfigValue.  Examples include type constructors like `int`
+        or `float`.  More complex domain examples include callable
+        objects; for example, the :py:class:`In` class that ensures that
+        the value falls into an acceptable set or even a complete
+        :py:class:`ConfigDict` instance.
+
+    description: str, optional
+        The short description of this value
+
+    doc: str, optional
+        The long documentation string for this value
+
+    visibility: int, optional
+        The visibility of this ConfigValue when generating templates and
+        documentation.  Visibility supports specification of "advanced"
+        or "developer" options.  ConfigValues with visibility=0 (the
+        default) will always be printed / included.  ConfigValues
+        with higher visibility values will only be included when the
+        generation method specifies a visibility greater than or equal
+        to the visibility of this object.
+    """
+    def __init__(self, *args, **kwds):
+        self._mutable = True
+        self._immutable_error_message = str(self) + ' is currently immutable.'
+        super(ImmutableConfigValue, self).__init__(*args, **kwds)
+
+    def set_value(self, value):
+        if not self._mutable:
+            raise RuntimeError(self._immutable_error_message)
+        super(ImmutableConfigValue, self).set_value(value)
+
+
 class ConfigList(ConfigBase):
     """Store and manipulate a list of configuration values.
 

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -1070,7 +1070,9 @@ class ConfigValue(ConfigBase):
 
 class ImmutableConfigValue(ConfigValue):
     def set_value(self, value):
-        raise RuntimeError(str(self) + ' is currently immutable')
+        if self._cast(value) != self._data:
+            raise RuntimeError(str(self) + ' is currently immutable')
+        super(ImmutableConfigValue, self).set_value(value)
 
     def reset(self):
         try:

--- a/pyutilib/misc/config.py
+++ b/pyutilib/misc/config.py
@@ -1069,50 +1069,27 @@ class ConfigValue(ConfigBase):
 
 
 class ImmutableConfigValue(ConfigValue):
-    """
-    A config value that supports temporary immutability.
-
-
-    Parameters
-    ----------
-    default: optional
-        The default value that this ConfigValue will take if no value is
-        provided.
-
-    domain: callable, optional
-        The domain can be any callable that accepts a candidate value
-        and returns the value converted to the desired type, optionally
-        performing any data validation.  The result will be stored into
-        the ConfigValue.  Examples include type constructors like `int`
-        or `float`.  More complex domain examples include callable
-        objects; for example, the :py:class:`In` class that ensures that
-        the value falls into an acceptable set or even a complete
-        :py:class:`ConfigDict` instance.
-
-    description: str, optional
-        The short description of this value
-
-    doc: str, optional
-        The long documentation string for this value
-
-    visibility: int, optional
-        The visibility of this ConfigValue when generating templates and
-        documentation.  Visibility supports specification of "advanced"
-        or "developer" options.  ConfigValues with visibility=0 (the
-        default) will always be printed / included.  ConfigValues
-        with higher visibility values will only be included when the
-        generation method specifies a visibility greater than or equal
-        to the visibility of this object.
-    """
-    def __init__(self, *args, **kwds):
-        self._mutable = True
-        self._immutable_error_message = str(self) + ' is currently immutable.'
-        super(ImmutableConfigValue, self).__init__(*args, **kwds)
-
     def set_value(self, value):
-        if not self._mutable:
-            raise RuntimeError(self._immutable_error_message)
-        super(ImmutableConfigValue, self).set_value(value)
+        raise RuntimeError(str(self) + ' is currently immutable')
+
+
+class MarkImmutable(object):
+    def __init__(self, *args):
+        self._locked = list()
+        try:
+            for arg in args:
+                if type(arg) is not ConfigValue:
+                    raise ValueError('Only ConfigValue instances can be marked immutable.')
+                arg.__class__ = ImmutableConfigValue
+                self._locked.append(arg)
+        except:
+            self.release_lock()
+            raise
+
+    def release_lock(self):
+        for arg in self._locked:
+            arg.__class__ = ConfigValue
+        self._locked = list()
 
 
 class ConfigList(ConfigBase):

--- a/pyutilib/misc/tests/test_config.py
+++ b/pyutilib/misc/tests/test_config.py
@@ -54,6 +54,10 @@ class TestImmutableConfigValue(unittest.TestCase):
             config.a = 4
         with self.assertRaises(Exception):
             config.b = 5
+        config.a = 2
+        config.b = 3
+        self.assertEqual(config.a, 2)
+        self.assertEqual(config.b, 3)
         locker.release_lock()
         config.a = 4
         config.b = 5

--- a/pyutilib/misc/tests/test_config.py
+++ b/pyutilib/misc/tests/test_config.py
@@ -65,6 +65,18 @@ class TestImmutableConfigValue(unittest.TestCase):
         config.a = 6
         self.assertEqual(config.a, 6)
 
+        config.declare('c', ConfigValue(default=-1, domain=int))
+        locker = MarkImmutable(config.get('a'), config.get('b'))
+        config2 = config({'c': -2})
+        self.assertEqual(config2.a, 6)
+        self.assertEqual(config2.b, 5)
+        self.assertEqual(config2.c, -2)
+        with self.assertRaises(Exception):
+            config3 = config({'a': 1})
+        locker.release_lock()
+        config3 = config({'a': 1})
+        self.assertEqual(config3.a, 1)
+
 
 class Test(unittest.TestCase):
 

--- a/pyutilib/misc/tests/test_config.py
+++ b/pyutilib/misc/tests/test_config.py
@@ -17,7 +17,7 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 import pyutilib.th as unittest
 
 import pyutilib.misc.comparison
-from pyutilib.misc.config import ConfigValue, ConfigBlock, ConfigList
+from pyutilib.misc.config import ConfigValue, ConfigBlock, ConfigList, MarkImmutable
 
 from six import PY3, StringIO
 
@@ -38,6 +38,33 @@ def _display(obj, *args):
     test = StringIO()
     obj.display(ostream=test, *args)
     return test.getvalue()
+
+
+class TestImmutableConfigValue(unittest.TestCase):
+    def test_immutable_config_value(self):
+        config = ConfigBlock()
+        config.declare('a', ConfigValue(default=1, domain=int))
+        config.declare('b', ConfigValue(default=1, domain=int))
+        config.a = 2
+        config.b = 3
+        self.assertEqual(config.a, 2)
+        self.assertEqual(config.b, 3)
+        locker = MarkImmutable(config.get('a'), config.get('b'))
+        with self.assertRaises(Exception):
+            config.a = 4
+        with self.assertRaises(Exception):
+            config.b = 5
+        locker.release_lock()
+        config.a = 4
+        config.b = 5
+        self.assertEqual(config.a, 4)
+        self.assertEqual(config.b, 5)
+        with self.assertRaises(ValueError):
+            locker = MarkImmutable(config.get('a'), config.b)
+        self.assertEqual(type(config.get('a')), ConfigValue)
+        config.a = 6
+        self.assertEqual(config.a, 6)
+
 
 class Test(unittest.TestCase):
 


### PR DESCRIPTION
## Changes proposed in this PR:
This PR adds a class derived from ConfigValue which can be made temporarily immutable by setting the `_mutable` attribute to `False`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
