### PR TITLE
Add `unittest.mock` backport

### DIFF
--- a/pyutilib/th/__init__.py
+++ b/pyutilib/th/__init__.py
@@ -25,3 +25,17 @@ try:
     import pyutilib.th.nose_timeout
 except ImportError:
     pass
+
+
+mock_available = False
+try:
+    from unittest import mock
+
+    mock_available = True
+except ImportError:
+    try:
+        import mock
+
+        mock_available = True
+    except ImportError:
+        pass


### PR DESCRIPTION
## Fixes: #

## Summary/Motivation:
- To allow usage of `unittest.mock` in packages that import pyutilib.th as unittest

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
