### PR TITLE
Log formatter should not combine lines starting "[\s*\S+\s*]"

### DIFF
--- a/pyutilib/misc/log_config.py
+++ b/pyutilib/misc/log_config.py
@@ -13,6 +13,7 @@ import sys
 import textwrap
 
 _indention = re.compile('\s*')
+_status_re = re.compile('^\[\s*[A-Za-z0-9\.]+\s*\]')
 
 class LogHandler(logging.Handler):
 
@@ -74,9 +75,10 @@ class LogHandler(logging.Handler):
                 # Blank lines reset the indentation level
                 indent = None
             elif indent == leading:
-                # Catch things like bulleted lists
-                if len(content) > 1 and par_lines and content[1] == ' ' \
-                   and content[0] in '-* ':
+                # Catch things like bulleted lists and '[FAIL]'
+                if len(content) > 1 and par_lines and (
+                        (content[1] == ' ' and content[0] in '-* ') or
+                        (content[0] == '[' and _status_re.match(content))):
                     paragraphs.append((indent, par_lines))
                     par_lines = []
                 par_lines.append( content )


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This prevents the log formatter from combining lines that begin with "`\[s*\S+\s*\]`", so that log messages like the following are not reformatted:
```
INFO: The following extensions were downloaded:
        [FAIL]  gsl
        [ OK ]  mcpp
```

## Changes proposed in this PR:
- Treat lines beginning with "`\[\s*[A-Za-z0-9]+\s*\]`" as if they were bulleted lists.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
