### PR TITLE
Support expanding user (~) and variables ($HOME) in import_file

### DIFF
--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -47,6 +47,8 @@ def import_file(filename, context=None, name=None, clear_cache=False):
     This function returns the module object that is created.
     """
 
+    # Support shell-style paths like ~user and $HOME/bin
+    filename = os.path.expanduser(os.path.expandvars(filename))
     #
     # Parse the filename to get the name of the module to be imported
     # and determine if it contains any directory information about
@@ -63,9 +65,7 @@ def import_file(filename, context=None, name=None, clear_cache=False):
     # For 2.4 compatibility we will call endswith() twice.
     if modulename.endswith('.py') or modulename.endswith('.pyc'):
         if not os.path.exists(filename):
-            if not os.path.exists(os.path.expanduser(filename)):
-                raise IOError("File %s does not exist" % (filename))
-            filename = os.path.expanduser(filename)
+            raise IOError("File %s does not exist" % (filename))
         if filename.endswith('.pyc'):
             filename = filename[:-1]
         modulename = modulename.rsplit('.', 1)[0]


### PR DESCRIPTION
## Fixes: #N/A

## Summary/Motivation:
This allows including user (`~/file.py`) and environment variables (e.g., `$HOME/file.py`) in the string passed to `import_file()`

## Changes proposed in this PR:
- Standardize variable processing in `import_file()` to allow the user (`~`) and environment variables.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
