### PR TITLE
Change badge from `active` to `inactive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![GitHub CI](https://github.com/PyUtilib/pyutilib/workflows/GitHub%20CI/badge.svg?branch=master)
 ![codecov.io](https://codecov.io/github/PyUtilib/pyutilib/coverage.svg?branch=master)
 [![Depsy Software Impact](http://depsy.org/api/package/pypi/PyUtilib/badge.svg)](http://depsy.org/package/python/PyUtilib)
-[![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
+[![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](https://www.repostatus.org/badges/latest/inactive.svg)](https://www.repostatus.org/#inactive)
 
 ## PyUtilib Overview
 
@@ -10,6 +10,8 @@ including a well-developed component architecture and extensions
 to the PyUnit testing framework. PyUtilib has been developed to
 support several Python-centric projects, especially
 [Pyomo](http://pyomo.org).
+
+This repository is currently inactive.
 
 PyUtilib is available under the BSD License.
 


### PR DESCRIPTION
## Fixes: NA

## Summary/Motivation:

We aren't actively doing anything with PyUtilib anymore, so the README should reflect that.

## Changes proposed in this PR:
- Change badge from `active` to `inactive`
- Add language that the repo is inactive

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
