### PR TITLE
Migrate imp to imporlib

### DIFF
--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -9,6 +9,7 @@
 
 import os
 import importlib
+import importlib.machinery
 import sys
 
 import pyutilib.common
@@ -22,6 +23,17 @@ except ImportError:  #pragma:nocover
         runpy_available = True
     except ImportError:  #pragma:nocover
         runpy_available = False
+
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 
 def import_file(filename, context=None, name=None, clear_cache=False):
@@ -142,7 +154,7 @@ def import_file(filename, context=None, name=None, clear_cache=False):
         try:
             # Note: we are always handing load_source a .py file, but
             #       it will use the .pyc or .pyo file if it exists
-            module = importlib.find_loader(name, pathname)
+            module = load_source(name, pathname)
         except:
             et, e, tb = sys.exc_info()
             import traceback

--- a/pyutilib/misc/import_file.py
+++ b/pyutilib/misc/import_file.py
@@ -8,7 +8,7 @@
 #  _________________________________________________________________________
 
 import os
-import imp
+import importlib
 import sys
 
 import pyutilib.common
@@ -125,15 +125,15 @@ def import_file(filename, context=None, name=None, clear_cache=False):
         else:
             if dirname is not None:
                 # find_module will return the .py file (never .pyc)
-                fp, pathname, description = imp.find_module(modulename,
-                                                            [dirname])
+                fp, pathname, description = importlib.find_loader(modulename,
+                                                            str(dirname))
                 fp.close()
             else:
                 try:
                     sys.path.insert(0, implied_dirname)
                     # find_module will return the .py file
                     # (never .pyc)
-                    fp, pathname, description = imp.find_module(modulename)
+                    fp, pathname, description = importlib.find_loader(modulename)
                     fp.close()
                 except ImportError:
                     raise
@@ -142,7 +142,7 @@ def import_file(filename, context=None, name=None, clear_cache=False):
         try:
             # Note: we are always handing load_source a .py file, but
             #       it will use the .pyc or .pyo file if it exists
-            module = imp.load_source(name, pathname)
+            module = importlib.find_loader(name, pathname)
         except:
             et, e, tb = sys.exc_info()
             import traceback


### PR DESCRIPTION
## Fixes: #111 and #114

## Summary/Motivation:
This fixes PyUtilLib in Python 3.12

## Changes proposed in this PR:
- Migrate code from imp to importlib

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
